### PR TITLE
Check for undefined content type

### DIFF
--- a/lib/kaiseki.js
+++ b/lib/kaiseki.js
@@ -320,7 +320,8 @@ Kaiseki.prototype = {
     request(this.API_BASE_URL + opts.url, reqOpts, function(err, res, body) {
       var isCountRequest = opts.params && !_.isUndefined(opts.params['count']) && !!opts.params.count;
       var success = !err && (res.statusCode === 200 || res.statusCode === 201);
-      if (res && res.headers['content-type'].toLowerCase().indexOf('application/json') >= 0) {
+      if (res && res.headers['content-type'] && 
+        res.headers['content-type'].toLowerCase().indexOf('application/json') >= 0) {
         if (!_.isObject(body) && !_.isArray(body)) // just in case it's been parsed already
           body = JSON.parse(body);
         if (body.error) {


### PR DESCRIPTION
Unfortunately, I don't have the exact repro steps, but in a production environment where I use kaiseki, sometimes res.headers['content-type'] is undefined. This commit adds a check for the content type header.

The fix is for this error (I was using an older version in production, so the line number was off):

2013-12-29T15:37:11.201Z - error: uncaughtException message=Cannot call method 'toLowerCase' of undefined, stack=TypeError: Cannot call method 'toLowerCase' of undefined

at Request._callback (/home/appuser/projects/rest-api/node_modules/kaiseki/lib/kaiseki.js:322:46)
    at Request.self.callback (/home/appuser/projects/rest-api/node_modules/kaiseki/node_modules/request/request.js:129:22)
    at Request.EventEmitter.emit (events.js:98:17)
    at Request.<anonymous> (/home/appuser/projects/rest-api/node_modules/kaiseki/node_modules/request/request.js:873:14)
    at Request.EventEmitter.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (/home/appuser/projects/rest-api/node_modules/kaiseki/node_modules/request/request.js:824:12)
