### PR TITLE
added support for drop-in session tokens

### DIFF
--- a/lib/kaiseki.js
+++ b/lib/kaiseki.js
@@ -51,8 +51,8 @@ Kaiseki.prototype = {
   getCurrentUser: function(sessionToken, callback) {
     this._jsonRequest({
       url: '/1/users/me',
-      callback: callback,
-      sessionToken: sessionToken
+      callback: callback || sessionToken, // fallback
+      sessionToken: (!callback ? null : sessionToken)
     });
   },
 


### PR DESCRIPTION
Using this on a server, it seems to make more sense to allow per-call specification on the session token, rather than only taking it in as an across-the-module variable.
