### PR TITLE
Fixed crash on JSON.parse() when response from Parse is blank (e.g., when deleting files)

### DIFF
--- a/lib/kaiseki.js
+++ b/lib/kaiseki.js
@@ -377,7 +377,7 @@ Kaiseki.prototype = {
     request(this.API_BASE_URL + opts.url, reqOpts, function(err, res, body) {
       var isCountRequest = opts.params && !_.isUndefined(opts.params['count']) && !!opts.params.count;
       var success = !err && (res.statusCode === 200 || res.statusCode === 201);
-      if (res && res.headers['content-type'] && 
+      if (body !== '' && res && res.headers['content-type'] && 
         res.headers['content-type'].toLowerCase().indexOf('application/json') >= 0) {
         if (!_.isObject(body) && !_.isArray(body)) // just in case it's been parsed already
           body = JSON.parse(body);


### PR DESCRIPTION
Thanks for the wonderful library! I noticed that my app was crashing whenever I called ```parse.deleteFile```, even though the delete operation seemed to be successful on the backend. I looked into this and found that the crash was caused when Kaiseki called ```JSON.parse()``` on a blank response from Parse (i.e., Parse would give a blank response with a 200 status code indicating that the operation was successful but there's nothing more to say). This pull request contains a super simple fix that checks for this condition and avoids the call to ```JSON.parse()``` when it occurs.